### PR TITLE
feat: Increase chunk size warning limit

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -42,7 +42,7 @@ export default defineConfig(({ mode }) => ({
         },
       },
     },
-    chunkSizeWarningLimit: 1000,
+    chunkSizeWarningLimit: 1600,
     sourcemap: mode !== "production",
   },
   plugins: [react(), expressPlugin()],


### PR DESCRIPTION
Increases the chunk size warning limit to 1600kb to avoid warnings during the build process.

Also corrects the location of `chunkSizeWarningLimit` and `sourcemap` properties in `vite.config.ts` by moving them inside the `build` object.